### PR TITLE
ERB: Add support for modern Ruby

### DIFF
--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -59,7 +59,7 @@ module Pkg::Util::File
 
     def erb_string(erbfile, b = binding)
       template = File.read(erbfile)
-      message  = ERB.new(template, nil, "-")
+      message  = ERB.new(template, trim_mode: '-')
       message.result(b)
     end
 


### PR DESCRIPTION
Without this, we get:

```
/code/target/staging/.bundle/gems/ruby/3.2.0/gems/packaging-0.122.3/lib/packaging/util/file.rb:67: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
2716
/code/target/staging/.bundle/gems/ruby/3.2.0/gems/packaging-0.122.3/lib/packaging/util/file.rb:67: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

