### PR TITLE
csv: Allow all 3.x releases

### DIFF
--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('artifactory', ['~> 3'])
   gem.add_dependency('base64', ['< 0.4'])
   gem.add_dependency('benchmark', ['< 0.5'])
-  gem.add_dependency('csv', ['3.1.5'])
+  gem.add_dependency('csv', ['~> 3.0'])
   gem.add_dependency('rake', ['>= 12.3'])
   gem.add_dependency('release-metrics')
   gem.require_path = 'lib'


### PR DESCRIPTION
This was pinned to 3.1.5 in d92a7543b9db124c79b9875ec1872325ec46e690 to not pull in Ruby 2.5. We now require Ruby 3.2+


